### PR TITLE
chore: revert OrbitForge branding for backfill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to OrbitForge
+# Contributing to StackHub
 
-We welcome contributions to OrbitForge! This guide will help you get started.
+We welcome contributions to StackHub! This guide will help you get started.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,60 @@
-# OrbitForge
+# StackHub
 
-OrbitForge is a multi-service Stacks dApp suite that brings marketplace trading, service billing, staking, and token launches into one cohesive hub.
+![Frontend CI](https://github.com/stackhub/stackhub/actions/workflows/frontend.yml/badge.svg)
+![Contracts CI](https://github.com/stackhub/stackhub/actions/workflows/contracts.yml/badge.svg)
+![License](https://img.shields.io/badge/license-MIT-blue)
 
-## What OrbitForge Includes
+## Overview
 
-- **NFT Marketplace** for minting, listings, and low-fee trades.
-- **Service Registry** to onboard providers and collect on-chain payments.
-- **Staking Vault** to lock STX and distribute rewards over time.
-- **Token Launchpad** to deploy SIP-010 assets with guardrails.
+StackHub is a comprehensive Stacks-based decentralized application (dApp) designed to empower the Bitcoin economy. It integrates a suite of DeFi and utility services into a single platform.
+
+## Key Features
+
+- **NFT Marketplace**: Mint, list, and trade NFTs with low platform fees.
+- **Service Registry**: Decentralized registry for service providers to list offerings and receive payments on-chain.
+- **Staking Vault**: Secure STX staking mechanism with time-locked rewards.
+- **Token Launchpad**: One-click deployment of SIP-010 fungible tokens.
 
 ## Getting Started
 
 ### Prerequisites
 
 - Node.js v18+
-- Clarinet
-- Stacks wallet (Leather, Xverse)
+- Clarinet (for contract development)
+- Stacks Wallet (Leather, Xverse)
 
-### Install
+### Installation
 
-```bash
-git clone https://github.com/floxxih/project-omega-hub.git
-cd project-omega-hub
-```
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/stackhub/stackhub.git
+   cd stackhub
+   ```
 
-### Frontend
+2. Install Frontend Dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
 
-```bash
-cd frontend
-npm install
-npm run dev
-```
+3. Run the Development Server:
+   ```bash
+   npm run dev
+   ```
 
-### Contracts + Tests
-
-```bash
-cd stackhub-contracts
-npm install
-npm run test
-```
-
-## Repository Layout
+## Project Structure
 
 ```
-project-omega-hub/
-├── stackhub-contracts/    # Smart contracts and tests
+stackhub/
+├── stackhub-contracts/    # Smart contracts (Clarinet project)
+│   ├── contracts/         # Clarity source code
+│   └── tests/             # TypeScript unit tests
 ├── frontend/              # Next.js web application
+│   ├── src/app/           # App Router pages
+│   └── src/lib/           # Contract integration logic
 └── README.md              # Project documentation
 ```
 
 ## License
 
-MIT
+This project is licensed under the MIT License.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# OrbitForge Frontend
+# StackHub Frontend
 
-This is the Next.js 16 frontend for the OrbitForge platform.
+This is the Next.js 16 frontend for the StackHub platform.
 
 ## Features
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "orbitforge-frontend",
+  "name": "stackhub-frontend",
   "version": "1.0.0",
-  "description": "Official frontend for OrbitForge dApp",
-  "author": "OrbitForge Team",
+  "description": "Official Frontend for StackHub dApp",
+  "author": "StackHub Team",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "OrbitForge | Premium DeFi on Stacks",
+  title: "StackHub | Premium DeFi on Stacks",
   description: "The all-in-one platform for NFTs, Tokens, Staking, and Services on the Stacks blockchain.",
   icons: {
     icon: "/logo.png",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ import { FEES } from "@/config/contracts";
 
 /**
  * Landing Page Component.
- * Displays the main features of the OrbitForge platform.
+ * Displays the main features of the StackHub platform.
  */
 export default function HomePage() {
   const { connected } = useWallet();
@@ -54,7 +54,7 @@ export default function HomePage() {
       {/* Hero Section */}
       <div className="text-center mb-16">
         <h1 className="text-5xl font-bold text-gray-900 mb-4">
-          Welcome to <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-blue-600">OrbitForge</span>
+          Welcome to <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-blue-600">StackHub</span>
         </h1>
         <p className="text-xl text-gray-600 max-w-2xl mx-auto">
           Your all-in-one DeFi platform on Stacks. Trade NFTs, launch tokens, stake STX, and access services - all with minimal fees.

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -13,11 +13,11 @@ export function Navbar() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-8">
-            <Link href="/" className="flex items-center space-x-2" aria-label="OrbitForge Home">
+            <Link href="/" className="flex items-center space-x-2" aria-label="StackHub Home">
               <div className="w-8 h-8 bg-gradient-to-br from-purple-600 to-blue-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-sm">SH</span>
               </div>
-              <span className="text-xl font-bold text-gray-900">OrbitForge</span>
+              <span className="text-xl font-bold text-gray-900">StackHub</span>
             </Link>
             
             <div className="hidden md:flex items-center space-x-6">

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -7,17 +7,17 @@ export function Footer() {
             <div className="w-6 h-6 bg-gray-200 rounded-md flex items-center justify-center">
               <span className="text-gray-600 font-bold text-xs">SH</span>
             </div>
-            <span className="text-gray-900 font-semibold">OrbitForge</span>
+            <span className="text-gray-900 font-semibold">StackHub</span>
           </div>
           
           <div className="text-sm text-gray-500">
-            &copy; {new Date().getFullYear()} OrbitForge. Built on Stacks.
+            &copy; {new Date().getFullYear()} StackHub. Built on Stacks.
           </div>
 
           <div className="flex space-x-6 text-sm text-gray-600">
             <a href="#" className="hover:text-gray-900">Terms</a>
             <a href="#" className="hover:text-gray-900">Privacy</a>
-            <a href="https://github.com/orbitforge" className="hover:text-gray-900">GitHub</a>
+            <a href="https://github.com/stackhub/stackhub" className="hover:text-gray-900">GitHub</a>
           </div>
         </div>
       </div>

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -1,5 +1,5 @@
 /**
- * OrbitForge Constants
+ * StackHub Constants
  * Centralized configuration values for the platform.
  */
 

--- a/frontend/src/context/ReownContext.tsx
+++ b/frontend/src/context/ReownContext.tsx
@@ -12,9 +12,9 @@ import { wagmiAdapter, projectId, networks } from '@/config/wagmi';
  * Displayed to users when connecting their wallets.
  */
 const metadata = {
-  name: 'OrbitForge',
+  name: 'StackHub',
   description: 'DeFi Platform on Stacks - NFT Marketplace, Token Launchpad, Staking & Services',
-  url: typeof window !== 'undefined' ? window.location.origin : 'https://orbitforge.app',
+  url: typeof window !== 'undefined' ? window.location.origin : 'https://stackhub.app',
   icons: ['/logo.png'],
 };
 

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -73,7 +73,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const connectStacks = () => {
     showConnect({
       appDetails: {
-        name: "OrbitForge",
+        name: "StackHub",
         icon: typeof window !== "undefined" ? window.location.origin + "/logo.png" : "/logo.png",
       },
       onFinish: () => {
@@ -122,3 +122,4 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 }
 
 export const useWallet = () => useContext(WalletContext);
+

--- a/frontend/src/lib/contracts.ts
+++ b/frontend/src/lib/contracts.ts
@@ -9,7 +9,7 @@ import {
 import { CONTRACTS } from "@/config/contracts";
 
 /**
- * Mint a new NFT on the OrbitForge marketplace.
+ * Mint a new NFT on the StackHub marketplace.
  * @param uri - The metadata URI for the NFT.
  * Initiates a contract call to `stackhub-nft-marketplace.mint`.
  */

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * OrbitForge Type Definitions
+ * StackHub Type Definitions
  * Shared TypeScript interfaces for the platform.
  */
 

--- a/stackhub-contracts/README.md
+++ b/stackhub-contracts/README.md
@@ -1,6 +1,6 @@
-# OrbitForge Smart Contracts
+# StackHub Smart Contracts
 
-This directory contains the Clarity smart contracts that power the OrbitForge platform.
+This directory contains the Clarity smart contracts that power the StackHub platform.
 
 ## Contracts Overview
 

--- a/stackhub-contracts/package.json
+++ b/stackhub-contracts/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "orbitforge-contracts-tests",
+  "name": "stackhub-contracts-tests",
   "version": "1.0.0",
-  "description": "Smart contract tests and scripts for OrbitForge",
+  "description": "Smart Contract Tests and Scripts for StackHub",
   "type": "module",
   "private": true,
   "scripts": {
@@ -9,7 +9,7 @@
     "test:report": "vitest run -- --coverage --costs",
     "test:watch": "chokidar \"tests/**/*.ts\" \"contracts/**/*.clar\" -c \"npm run test:report\""
   },
-  "author": "OrbitForge Team",
+  "author": "StackHub Team",
   "license": "ISC",
   "keywords": [
     "stacks",

--- a/stackhub-contracts/tests/stackhub-nft-marketplace.test.ts
+++ b/stackhub-contracts/tests/stackhub-nft-marketplace.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Cl } from "@stacks/transactions";
 
 /**
- * Test Suite: OrbitForge NFT Marketplace
+ * Test Suite: StackHub NFT Marketplace
  * Covers minting, listing, buying, and unlisting functionality.
  * Verifies fee transfers and ownership changes.
  */
@@ -12,7 +12,7 @@ const deployer = accounts.get("deployer")!;
 const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
-describe("OrbitForge NFT Marketplace", () => {
+describe("StackHub NFT Marketplace", () => {
   describe("mint", () => {
     it("should mint an NFT successfully", () => {
       const { result } = simnet.callPublicFn(

--- a/stackhub-contracts/tests/stackhub-service-registry.test.ts
+++ b/stackhub-contracts/tests/stackhub-service-registry.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Cl } from "@stacks/transactions";
 
 /**
- * Test Suite: OrbitForge Service Registry
+ * Test Suite: StackHub Service Registry
  * Tests service registration, updates, status toggling, and payments.
  * Ensures platform fees are collected correctly.
  */
@@ -12,7 +12,7 @@ const deployer = accounts.get("deployer")!;
 const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
-describe("OrbitForge Service Registry", () => {
+describe("StackHub Service Registry", () => {
   describe("register-service", () => {
     it("should register a service and pay fee", () => {
       const { result } = simnet.callPublicFn(

--- a/stackhub-contracts/tests/stackhub-staking-vault.test.ts
+++ b/stackhub-contracts/tests/stackhub-staking-vault.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Cl } from "@stacks/transactions";
 
 /**
- * Test Suite: OrbitForge Staking Vault
+ * Test Suite: StackHub Staking Vault
  * Validates staking logic, unstake requests, and time-lock mechanisms.
  * Checks mathematical accuracy of potential rewards (mocked).
  */
@@ -12,7 +12,7 @@ const deployer = accounts.get("deployer")!;
 const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
-describe("OrbitForge Staking Vault", () => {
+describe("StackHub Staking Vault", () => {
   describe("stake", () => {
     it("should stake STX successfully", () => {
       const { result } = simnet.callPublicFn(

--- a/stackhub-contracts/tests/stackhub-token-launchpad.test.ts
+++ b/stackhub-contracts/tests/stackhub-token-launchpad.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Cl } from "@stacks/transactions";
 
 /**
- * Test Suite: OrbitForge Token Launchpad
+ * Test Suite: StackHub Token Launchpad
  * Verifies token creation (SIP-010 derived), supply management, and creation fees.
  * Ensures metadata is stored correctly.
  */
@@ -12,7 +12,7 @@ const deployer = accounts.get("deployer")!;
 const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
-describe("OrbitForge Token Launchpad", () => {
+describe("StackHub Token Launchpad", () => {
   describe("create-token", () => {
     it("should create a token and pay fee", () => {
       const { result } = simnet.callPublicFn(


### PR DESCRIPTION
## Summary
- revert the direct-to-main OrbitForge branding commit to enable PR-based reapply

## Testing
- not run (revert-only change)
