### PR TITLE
refactor: rename StackHub branding to OrbitForge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to StackHub
+# Contributing to OrbitForge
 
-We welcome contributions to StackHub! This guide will help you get started.
+We welcome contributions to OrbitForge! This guide will help you get started.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -1,60 +1,54 @@
-# StackHub
+# OrbitForge
 
-![Frontend CI](https://github.com/stackhub/stackhub/actions/workflows/frontend.yml/badge.svg)
-![Contracts CI](https://github.com/stackhub/stackhub/actions/workflows/contracts.yml/badge.svg)
-![License](https://img.shields.io/badge/license-MIT-blue)
+OrbitForge is a multi-service Stacks dApp suite that brings marketplace trading, service billing, staking, and token launches into one cohesive hub.
 
-## Overview
+## What OrbitForge Includes
 
-StackHub is a comprehensive Stacks-based decentralized application (dApp) designed to empower the Bitcoin economy. It integrates a suite of DeFi and utility services into a single platform.
-
-## Key Features
-
-- **NFT Marketplace**: Mint, list, and trade NFTs with low platform fees.
-- **Service Registry**: Decentralized registry for service providers to list offerings and receive payments on-chain.
-- **Staking Vault**: Secure STX staking mechanism with time-locked rewards.
-- **Token Launchpad**: One-click deployment of SIP-010 fungible tokens.
+- **NFT Marketplace** for minting, listings, and low-fee trades.
+- **Service Registry** to onboard providers and collect on-chain payments.
+- **Staking Vault** to lock STX and distribute rewards over time.
+- **Token Launchpad** to deploy SIP-010 assets with guardrails.
 
 ## Getting Started
 
 ### Prerequisites
 
 - Node.js v18+
-- Clarinet (for contract development)
-- Stacks Wallet (Leather, Xverse)
+- Clarinet
+- Stacks wallet (Leather, Xverse)
 
-### Installation
+### Install
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/stackhub/stackhub.git
-   cd stackhub
-   ```
+```bash
+git clone https://github.com/floxxih/project-omega-hub.git
+cd project-omega-hub
+```
 
-2. Install Frontend Dependencies:
-   ```bash
-   cd frontend
-   npm install
-   ```
+### Frontend
 
-3. Run the Development Server:
-   ```bash
-   npm run dev
-   ```
+```bash
+cd frontend
+npm install
+npm run dev
+```
 
-## Project Structure
+### Contracts + Tests
+
+```bash
+cd stackhub-contracts
+npm install
+npm run test
+```
+
+## Repository Layout
 
 ```
-stackhub/
-├── stackhub-contracts/    # Smart contracts (Clarinet project)
-│   ├── contracts/         # Clarity source code
-│   └── tests/             # TypeScript unit tests
+project-omega-hub/
+├── stackhub-contracts/    # Smart contracts and tests
 ├── frontend/              # Next.js web application
-│   ├── src/app/           # App Router pages
-│   └── src/lib/           # Contract integration logic
 └── README.md              # Project documentation
 ```
 
 ## License
 
-This project is licensed under the MIT License.
+MIT

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# StackHub Frontend
+# OrbitForge Frontend
 
-This is the Next.js 16 frontend for the StackHub platform.
+This is the Next.js 16 frontend for the OrbitForge platform.
 
 ## Features
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "stackhub-frontend",
+  "name": "orbitforge-frontend",
   "version": "1.0.0",
-  "description": "Official Frontend for StackHub dApp",
-  "author": "StackHub Team",
+  "description": "Official frontend for OrbitForge dApp",
+  "author": "OrbitForge Team",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "StackHub | Premium DeFi on Stacks",
+  title: "OrbitForge | Premium DeFi on Stacks",
   description: "The all-in-one platform for NFTs, Tokens, Staking, and Services on the Stacks blockchain.",
   icons: {
     icon: "/logo.png",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ import { FEES } from "@/config/contracts";
 
 /**
  * Landing Page Component.
- * Displays the main features of the StackHub platform.
+ * Displays the main features of the OrbitForge platform.
  */
 export default function HomePage() {
   const { connected } = useWallet();
@@ -54,7 +54,7 @@ export default function HomePage() {
       {/* Hero Section */}
       <div className="text-center mb-16">
         <h1 className="text-5xl font-bold text-gray-900 mb-4">
-          Welcome to <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-blue-600">StackHub</span>
+          Welcome to <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-blue-600">OrbitForge</span>
         </h1>
         <p className="text-xl text-gray-600 max-w-2xl mx-auto">
           Your all-in-one DeFi platform on Stacks. Trade NFTs, launch tokens, stake STX, and access services - all with minimal fees.

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -13,11 +13,11 @@ export function Navbar() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-8">
-            <Link href="/" className="flex items-center space-x-2" aria-label="StackHub Home">
+            <Link href="/" className="flex items-center space-x-2" aria-label="OrbitForge Home">
               <div className="w-8 h-8 bg-gradient-to-br from-purple-600 to-blue-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-sm">SH</span>
               </div>
-              <span className="text-xl font-bold text-gray-900">StackHub</span>
+              <span className="text-xl font-bold text-gray-900">OrbitForge</span>
             </Link>
             
             <div className="hidden md:flex items-center space-x-6">

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -7,17 +7,17 @@ export function Footer() {
             <div className="w-6 h-6 bg-gray-200 rounded-md flex items-center justify-center">
               <span className="text-gray-600 font-bold text-xs">SH</span>
             </div>
-            <span className="text-gray-900 font-semibold">StackHub</span>
+            <span className="text-gray-900 font-semibold">OrbitForge</span>
           </div>
           
           <div className="text-sm text-gray-500">
-            &copy; {new Date().getFullYear()} StackHub. Built on Stacks.
+            &copy; {new Date().getFullYear()} OrbitForge. Built on Stacks.
           </div>
 
           <div className="flex space-x-6 text-sm text-gray-600">
             <a href="#" className="hover:text-gray-900">Terms</a>
             <a href="#" className="hover:text-gray-900">Privacy</a>
-            <a href="https://github.com/stackhub/stackhub" className="hover:text-gray-900">GitHub</a>
+            <a href="https://github.com/orbitforge" className="hover:text-gray-900">GitHub</a>
           </div>
         </div>
       </div>

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -1,5 +1,5 @@
 /**
- * StackHub Constants
+ * OrbitForge Constants
  * Centralized configuration values for the platform.
  */
 

--- a/frontend/src/context/ReownContext.tsx
+++ b/frontend/src/context/ReownContext.tsx
@@ -12,9 +12,9 @@ import { wagmiAdapter, projectId, networks } from '@/config/wagmi';
  * Displayed to users when connecting their wallets.
  */
 const metadata = {
-  name: 'StackHub',
+  name: 'OrbitForge',
   description: 'DeFi Platform on Stacks - NFT Marketplace, Token Launchpad, Staking & Services',
-  url: typeof window !== 'undefined' ? window.location.origin : 'https://stackhub.app',
+  url: typeof window !== 'undefined' ? window.location.origin : 'https://orbitforge.app',
   icons: ['/logo.png'],
 };
 

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -73,7 +73,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const connectStacks = () => {
     showConnect({
       appDetails: {
-        name: "StackHub",
+        name: "OrbitForge",
         icon: typeof window !== "undefined" ? window.location.origin + "/logo.png" : "/logo.png",
       },
       onFinish: () => {
@@ -122,4 +122,3 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 }
 
 export const useWallet = () => useContext(WalletContext);
-

--- a/frontend/src/lib/contracts.ts
+++ b/frontend/src/lib/contracts.ts
@@ -9,7 +9,7 @@ import {
 import { CONTRACTS } from "@/config/contracts";
 
 /**
- * Mint a new NFT on the StackHub marketplace.
+ * Mint a new NFT on the OrbitForge marketplace.
  * @param uri - The metadata URI for the NFT.
  * Initiates a contract call to `stackhub-nft-marketplace.mint`.
  */

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * StackHub Type Definitions
+ * OrbitForge Type Definitions
  * Shared TypeScript interfaces for the platform.
  */
 

--- a/stackhub-contracts/README.md
+++ b/stackhub-contracts/README.md
@@ -1,6 +1,6 @@
-# StackHub Smart Contracts
+# OrbitForge Smart Contracts
 
-This directory contains the Clarity smart contracts that power the StackHub platform.
+This directory contains the Clarity smart contracts that power the OrbitForge platform.
 
 ## Contracts Overview
 

--- a/stackhub-contracts/package.json
+++ b/stackhub-contracts/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "stackhub-contracts-tests",
+  "name": "orbitforge-contracts-tests",
   "version": "1.0.0",
-  "description": "Smart Contract Tests and Scripts for StackHub",
+  "description": "Smart contract tests and scripts for OrbitForge",
   "type": "module",
   "private": true,
   "scripts": {
@@ -9,7 +9,7 @@
     "test:report": "vitest run -- --coverage --costs",
     "test:watch": "chokidar \"tests/**/*.ts\" \"contracts/**/*.clar\" -c \"npm run test:report\""
   },
-  "author": "StackHub Team",
+  "author": "OrbitForge Team",
   "license": "ISC",
   "keywords": [
     "stacks",

--- a/stackhub-contracts/tests/stackhub-nft-marketplace.test.ts
+++ b/stackhub-contracts/tests/stackhub-nft-marketplace.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Cl } from "@stacks/transactions";
 
 /**
- * Test Suite: StackHub NFT Marketplace
+ * Test Suite: OrbitForge NFT Marketplace
  * Covers minting, listing, buying, and unlisting functionality.
  * Verifies fee transfers and ownership changes.
  */
@@ -12,7 +12,7 @@ const deployer = accounts.get("deployer")!;
 const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
-describe("StackHub NFT Marketplace", () => {
+describe("OrbitForge NFT Marketplace", () => {
   describe("mint", () => {
     it("should mint an NFT successfully", () => {
       const { result } = simnet.callPublicFn(

--- a/stackhub-contracts/tests/stackhub-service-registry.test.ts
+++ b/stackhub-contracts/tests/stackhub-service-registry.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Cl } from "@stacks/transactions";
 
 /**
- * Test Suite: StackHub Service Registry
+ * Test Suite: OrbitForge Service Registry
  * Tests service registration, updates, status toggling, and payments.
  * Ensures platform fees are collected correctly.
  */
@@ -12,7 +12,7 @@ const deployer = accounts.get("deployer")!;
 const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
-describe("StackHub Service Registry", () => {
+describe("OrbitForge Service Registry", () => {
   describe("register-service", () => {
     it("should register a service and pay fee", () => {
       const { result } = simnet.callPublicFn(

--- a/stackhub-contracts/tests/stackhub-staking-vault.test.ts
+++ b/stackhub-contracts/tests/stackhub-staking-vault.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Cl } from "@stacks/transactions";
 
 /**
- * Test Suite: StackHub Staking Vault
+ * Test Suite: OrbitForge Staking Vault
  * Validates staking logic, unstake requests, and time-lock mechanisms.
  * Checks mathematical accuracy of potential rewards (mocked).
  */
@@ -12,7 +12,7 @@ const deployer = accounts.get("deployer")!;
 const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
-describe("StackHub Staking Vault", () => {
+describe("OrbitForge Staking Vault", () => {
   describe("stake", () => {
     it("should stake STX successfully", () => {
       const { result } = simnet.callPublicFn(

--- a/stackhub-contracts/tests/stackhub-token-launchpad.test.ts
+++ b/stackhub-contracts/tests/stackhub-token-launchpad.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Cl } from "@stacks/transactions";
 
 /**
- * Test Suite: StackHub Token Launchpad
+ * Test Suite: OrbitForge Token Launchpad
  * Verifies token creation (SIP-010 derived), supply management, and creation fees.
  * Ensures metadata is stored correctly.
  */
@@ -12,7 +12,7 @@ const deployer = accounts.get("deployer")!;
 const wallet1 = accounts.get("wallet_1")!;
 const wallet2 = accounts.get("wallet_2")!;
 
-describe("StackHub Token Launchpad", () => {
+describe("OrbitForge Token Launchpad", () => {
   describe("create-token", () => {
     it("should create a token and pay fee", () => {
       const { result } = simnet.callPublicFn(


### PR DESCRIPTION
## Summary
- rename StackHub branding to OrbitForge across docs, frontend metadata, and UI copy
- refresh README setup instructions to reflect the new suite name

## Testing
- not run (branding-only changes)
